### PR TITLE
演習の解答例をすぐには見えないようにした

### DIFF
--- a/chapter_2/README.md
+++ b/chapter_2/README.md
@@ -124,6 +124,9 @@ Bye!
 
 ヒント: `|` をつかって複数のルールを定義することができる。
 
+<details>
+<summary>解答例</summary>
+
 ```ruby
 rule
   program: NUMBER '+' NUMBER { p "#{val[0]} + #{val[2]} = #{val[0] + val[2]}" }
@@ -133,6 +136,7 @@ rule
 
 end
 ```
+</details>
 
 ```shell
 $ rake

--- a/chapter_3/README.md
+++ b/chapter_3/README.md
@@ -243,6 +243,9 @@ expr: expr '+' term
 
 ヒント: `|` をつかって複数のルールを定義することができる。
 
+<details>
+<summary>解答例</summary>
+
 ```ruby
 rule
   program: expr { p "program is #{val[0]}. result is #{result}." }
@@ -257,6 +260,7 @@ rule
       ;
 end
 ```
+</details>
 
 ```shell
 $ rake

--- a/chapter_4/README.md
+++ b/chapter_4/README.md
@@ -122,6 +122,9 @@ end
 
 ヒント: `|` をつかって掛け算と同じところにルールを定義する。
 
+<details>
+<summary>解答例</summary>
+
 ```ruby
 rule
   program: expr { p "program is #{val[0]}. result is #{result}." }
@@ -141,6 +144,7 @@ rule
          ;
 end
 ```
+</details>
 
 ```shell
 $ rake


### PR DESCRIPTION
演習を解こうと思っても、すぐ見える箇所に解答例があるのでつい見てしまいます。折りたたみセクションを使って解答例を折りたたむことで演習について考える余地を作りました。

ref: [セクションを折りたたんで情報を整理する - GitHub Docs](https://docs.github.com/ja/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections#creating-a-collapsed-section)